### PR TITLE
Fix error of EDX trying to get resource_path

### DIFF
--- a/vimeo/vimeo.py
+++ b/vimeo/vimeo.py
@@ -51,7 +51,7 @@ class VimeoBlock(XBlock):
         data = pkg_resources.resource_string(__name__, path)
         return data.decode("utf8")
 
-    def load_resource(self, path):
+    def load_resource(self, resource_path):
         """
         Gets Content of a Resource and Encodes it to UTF-8 For Python 2.7
         """


### PR DESCRIPTION
Installing on a clean Ironwood machine, there's an error when trying to using it.

Error: global name 'resource_path' is not defined 

Looking in the code, the only appearance of the 'resource_paht' variable name is in that line, and looks like some misspelling.
Changing it and installing resolves the problem and the Xblock is usable.